### PR TITLE
Remove `BUILDPACK_NAME` from the deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The different tasks are specified in the `composer.json` file of the PHP project
 
 ```
 scalingo create my-app
-scalingo --app my-app env-set BUILDPACK_NAME=php DOCUMENT_ROOT=/
+scalingo --app my-app env-set DOCUMENT_ROOT=/
 git push scalingo master
 ```
 


### PR DESCRIPTION
fix #2 